### PR TITLE
Retarget extension documentation URL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -5,7 +5,7 @@
 		"WikiTeq",
 		"Vedmaka"
 	],
-	"url": "https://www.mediawiki.org/wiki/Extension:RemoteWiki",
+	"url": "https://github.com/WikiTeq/mediawiki-extension-RemoteWiki#readme",
 	"descriptionmsg": "remotewiki-desc",
 	"license-name": "MIT",
 	"requires": {


### PR DESCRIPTION
Instead of pointing to a missing page on MediaWiki.org, use the repository's documentation.