### PR TITLE
Allow querying extension URLs instead of versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RemoteWiki
 
 The extension provides `{{#remote_version:}}` parser function capable to fetch
-remote MediaWiki version and installed extensions versions data. Supports authentication
+remote MediaWiki version and installed extensions versions and URLs data. Supports authentication
 via [BotPasswords](https://www.mediawiki.org/wiki/Manual:Bot_passwords).
 
 # Requirements
@@ -34,6 +34,12 @@ Fetch remote wiki extensions versions
 {{#remote_version:https://wiki.com/w/api.php|extensions}}
 ```
 
+Fetch remote wiki extensions URLs
+
+```
+{{#remote_version:https://wiki.com/w/api.php|extension-urls}}
+```
+
 For private wiki add bot credentials into `$wgRemoteWikiBotPasswords` setting like below:
 
 ```php
@@ -51,7 +57,10 @@ $wgRemoteWikiBotPasswords['mywiki.com/w/api.php'] = [
 {{#remote_version:https://wiki.com/w/api.php}} = 1.35.5
 ```
 
-`remote_version` with 2nd argument set to `extensions` will return list of extensions and their versions (if any) or git commits (if version information is missing) or empty string if version can't be detected, using `:` as an separator between extension and version and `,` as a record separator, eg:
+`remote_version` with 2nd argument set to `extensions` will return list of
+extensions and their versions (if any) or git commits (if version information
+is missing) or question marks if version can't be detected, using `:` as an
+separator between extension and version and `,` as a record separator, eg:
 
 ```
 {{#remote_version:https://wiki.com/w/api.php|extensions}} = ParserFunctions:1.0,SemanticWatchlist:2.0,PageForms:5.0
@@ -66,13 +75,40 @@ Displays table of extensions and their versions
 ! Extension
 ! Version
 |-
-{{#arraymap:{{#remote_version:[https://en.wikipedia.org/w/api.php](https://wiki.com/w/api.php)|extensions}}
+{{#arraymap:{{#remote_version:https://wiki.com/w/api.php|extensions}}
 |,
 |@
 |
 {{!}}-
 {{!}} '''{{#explode:@|:|0}}'''
 {{!}} <code>{{#explode:@|:|1}}</code>
+{{!}}-
+| 
+}}
+|-
+|}
+```
+
+`remote_version` with 2nd argument set to `extension-urls` will return list of
+extensions and their URLs (if any) or question marks if the URL is not set,
+using `:` as a separator between extension and URL and `|` as a record
+separator (rather than `,` since commas are valid in URLs). A formatted output
+can be achieved with:
+
+```
+Displays table of extensions and their URLs
+
+{|class="wikitable"
+! Extension
+! URL
+|-
+{{#arraymap:{{#remote_version:https://wiki.com/w/api.php|extension-urls}}
+|{{!}}
+|@
+|
+{{!}}-
+{{!}} '''{{#explode:@|:|0}}'''
+{{!}} <code>{{#explode:@|:|1|2}}</code>
 {{!}}-
 | 
 }}

--- a/tests/phpunit/integration/RemoteWikiTest.php
+++ b/tests/phpunit/integration/RemoteWikiTest.php
@@ -64,9 +64,10 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
      * that might be the reason.
      * 
      * @covers ::remoteVersion
-     * @covers ::getExtensions
+     * @covers ::getExtensionVersions
+     * @covers ::getExtensionsInfo
      */
-    public function testExtensions() {
+    public function testExtensionVersions() {
         $parser = $this->createNoOpMock( Parser::class );
         $mwEndpoint = 'https://www.mediawiki.org/w/api.php';
         $remote = MediaWikiServices::getInstance()->getService( 'RemoteWiki' );
@@ -80,6 +81,39 @@ class RemoteWikiTest extends MediaWikiIntegrationTestCase {
             'Math:',
             $extensions,
             'Math version retrieved'
+        );
+        $this->assertStringNotContainsString(
+            'Math:http',
+            $extensions,
+            'Math version is not a URL'
+        );
+    }
+
+    /**
+     * This test assumes that MediaWiki.org has the 'Math' extension installed
+     * and enabled, and the URL for that extension begins with http (i.e. is
+     * set)- since the extension is bundled with MediaWiki it is unlikely that
+     * it will become disabled, but if this test starts failing that might be
+     * the reason.
+     * 
+     * @covers ::remoteVersion
+     * @covers ::getExtensionURLs
+     * @covers ::getExtensionsInfo
+     */
+    public function testExtensionUrls() {
+        $parser = $this->createNoOpMock( Parser::class );
+        $mwEndpoint = 'https://www.mediawiki.org/w/api.php';
+        $remote = MediaWikiServices::getInstance()->getService( 'RemoteWiki' );
+
+        $extensions = $remote->remoteVersion(
+            $parser,
+            $mwEndpoint,
+            'extension-urls'
+        );
+        $this->assertStringContainsString(
+            'Math:http',
+            $extensions,
+            'Math URL retrieved'
         );
     }
 


### PR DESCRIPTION
Specifically:
- Add a new type, 'extension-urls', used with `{{#remote_version:{url}|extension-urls}}`

- Querying for versions remains the same with `{{#remote_version:{url}|extensions}}`

- The data about extensions is cached together since it comes from the same API response

- The extension URLs are separated with a pipe (`|`) in the output instead of a comma, since commas are valid URL characters

- Tests updated

- README updated

MAIN-566