### PR TITLE
Do not crash if addwiki/mediawiki-api-base is missing

### DIFF
--- a/src/RemoteWiki.php
+++ b/src/RemoteWiki.php
@@ -52,6 +52,14 @@ class RemoteWiki {
 	 * @return string
 	 */
 	public function remoteVersion( Parser $parser, $endPoint = null, $type = null ): string {
+		// Verify that the `addwiki/mediawiki-api-base` composer dependency is
+		// installed - we check if the `Addwiki\Mediawiki\Api\Client\MediaWiki`
+		// class is installed and assume that if it is, the entire package is
+		// available.
+		if ( !class_exists( MediaWiki::class ) ) {
+			return '(RemoteWiki: addwiki/mediawiki-api-base not installed)';
+		}
+
 		if ( !$this->validateEndpoint( $endPoint ) ) {
 			return '';
 		}


### PR DESCRIPTION
Instead of crashing with a fatal error and a stack trace, check if one of the classes that we need is available, using that class as a proxy for the overall package. If not, uses of the parser function return a nice error message but the parsing does not fail and the rest of the page can be shown.

WIK-1250